### PR TITLE
Fix event stream format: messages need to be terminated with \n\n instead of one \n

### DIFF
--- a/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
+++ b/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
@@ -61,10 +61,10 @@ class MetricsServer
             $stats = $this->metricsPoller->getStatsForCommandsRunning();
 
             if (empty($stats)) {
-                echo "ping: \n";
+                echo "ping: \n\n";
             } else {
                 foreach ($stats as $commandStats) {
-                    echo "data: " . json_encode($commandStats) . "\n";
+                    echo "data: " . json_encode($commandStats) . "\n\n";
                 }
             }
 


### PR DESCRIPTION
See: http://www.html5rocks.com/en/tutorials/eventsource/basics/

The hystrix implementation does this correctly (https://github.com/Netflix/Hystrix/blob/master/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java#L155) here println automatically sends an additional newline which the php echo does not. Because of this the dashboard proxy does not work and throws org.mortbay.jetty.EofException.
