### PR TITLE
Utilize time_nanosleep() instead of usleep()

### DIFF
--- a/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
+++ b/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
@@ -70,7 +70,7 @@ class MetricsServer
 
             ob_flush();
             flush();
-            time_nanosleep(0, $this->delay * 1000);
+            time_nanosleep(0, $this->delay * 1000000);
         }
     }
 }

--- a/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
+++ b/src/Odesk/PhystrixDashboard/MetricsEventStream/MetricsServer.php
@@ -70,7 +70,7 @@ class MetricsServer
 
             ob_flush();
             flush();
-            usleep($this->delay * 1000);
+            time_nanosleep(0, $this->delay * 1000);
         }
     }
 }


### PR DESCRIPTION
After trying to troubleshoot some problems encountered while implementing this dashboard stream, my investigation pointed towards the usleep() function. I ended up adjusting the run() function to use time_nanosleep() instead of usleep() for (http://php.net/manual/en/function.usleep.php#118258). This fixed my issues, so I figured it would be a good idea to contribute this change.
